### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,18 @@ Depending on the configuration of your Limnoria instance and your web server the
 plugin now listens on the following address where it accepts the network and the
 channel as a parameter:
 
-`http://<host>:<port>/gitlab/<network>/<channel>`
+`http://<host>:<port>/gitlab/<network>`
 
 The placeholders are defined as followed:
 
   - `<host>` - The host defined by the external IP of the service
   - `<port>` - The port that the HTTP server of Limnoria listens to
   - `<network>` - The network that the Limnoria instance is connected to
-  - `<channel>` - The channel that the Limnoria instance is in
 
 For instance if your bot is in the _OFTC_ network and in the _#limnoria-gitlab_
 channel, the plugin listens on the following URL for webhook notifications:
 
-`http://limnoria.example.com:8080/gitlab/OFTC/limnoria-gitlab`
+`http://limnoria.example.com:8080/gitlab/OFTC`
 
 Now you need to add this address as a new webhook in the project settings of
 your Gitlab instance. Therefore you go to `Settings -> Webhooks`

--- a/config.py
+++ b/config.py
@@ -57,6 +57,8 @@ conf.registerChannelValue(Gitlab, 'projects',
 # Format
 conf.registerGroup(Gitlab, 'format')
 
+conf.registerChannelValue(Gitlab, 'use-notices',
+    registry.Boolean(False, _("""Determines whether the bot should announce using NOTICE instead of PRIVMSG.""")))
 conf.registerChannelValue(Gitlab.format, 'push',
     registry.String(_("""\x02[{project[name]}]\x02 {user_name} pushed \x02{total_commits_count} commit(s)\x02 to \x02{ref}\x02:"""),
                     _("""Format for push events.""")))

--- a/plugin.py
+++ b/plugin.py
@@ -199,8 +199,11 @@ class GitlabHandler(object):
         return msg
 
     def _send_message(self, channel, msg):
-        priv_msg = ircmsgs.privmsg(channel, msg)
-        self.irc.queueMsg(priv_msg)
+        if self.plugin.registryValue('use-notices', channel):
+            announce_msg = ircmsgs.notice(channel, msg)
+        else:
+            announce_msg = ircmsgs.privmsg(channel, msg)
+        self.irc.queueMsg(announce_msg)
 
 
 class GitlabWebHookService(httpserver.SupyHTTPServerCallback):

--- a/plugin.py
+++ b/plugin.py
@@ -230,24 +230,17 @@ class GitlabWebHookService(httpserver.SupyHTTPServerCallback):
         headers = dict(self.headers)
 
         network = None
-        channel = None
-
         try:
             information = path.split('/')[1:]
             network = information[0]
-            channel = '#' + information[1]
         except IndexError:
             self._send_error(handler, _("""Error: You need to provide the
-                                        network name and the channel in
-                                        url."""))
+                                        network name in the URL."""))
             return
 
         irc = world.getIrc(network)
         if irc is None:
             self._send_error(handler, (_('Error: Unknown network %r') % network))
-            return
-        elif channel not in irc.state.channels:
-            self._send_error(handler, (_('Error: Unknown channel %r') % channel))
             return
 
         # Handle payload

--- a/plugin.py
+++ b/plugin.py
@@ -58,7 +58,7 @@ class GitlabHandler(object):
     def __init__(self, plugin):
         self.plugin = plugin
         self.log = log.getPluginLogger('Gitlab')
-        # HACK: instead of refactoring everything, I can just replace with each handle_payload() call.
+        # HACK: instead of refactoring everything, I can just replace this with each handle_payload() call.
         self.irc = None
 
     def handle_payload(self, headers, payload, irc):
@@ -273,7 +273,10 @@ class Gitlab(callbacks.Plugin):
 
     def __init__(self, irc):
         global instance
-        super(Gitlab, self).__init__(irc)
+
+        # Store the super() information so that reloads don't fail
+        self.__parent = super(Gitlab, self)
+        self.__parent.__init__(irc)
         instance = self
 
         callback = GitlabWebHookService(self)
@@ -282,7 +285,7 @@ class Gitlab(callbacks.Plugin):
     def die(self):
         httpserver.unhook('gitlab')
 
-        super(Gitlab, self).die()
+        self.__parent.die()
 
     def _load_projects(self, channel):
         projects = self.registryValue('projects', channel)


### PR DESCRIPTION
Hi,

I recently tried your plugin with [Debian's GitLab instance](https://salsa.debian.org/), and made some adjustments to better suit the needs of my setup. I've consolidated the patches that my instance uses into one PR:

- 140d724 adds support for multiple networks: instead of fixing the webhook handler to the network where the plugin was loaded, make the plugin dynamically search through networks (much like it already did with channels).
    - This also makes the plugin raise an explicit error if a network/channel target is unknown, instead of breaking the connection immediately and leaving frontend servers with confusing 502 (Bad Gateway) errors.
- 630786e drops channel names from the webhook target URL, since they weren't actually being read from. Backwards compatibility with old links are still kept.
- 3c0d66e adds an option to make the plugin announce as NOTICE instead of PRIVMSG
- f5ffcee fixes TypeError problems when reloading on Python 3 (though the fix should also work on Python 2)

Thanks for the work!